### PR TITLE
Client RPC

### DIFF
--- a/include/ipc-client.hpp
+++ b/include/ipc-client.hpp
@@ -17,6 +17,7 @@
 
 #pragma once
 #include "ipc.hpp"
+#include "ipc-class.hpp"
 #include <string>
 #include <vector>
 #include <map>
@@ -37,6 +38,9 @@ namespace ipc {
 		std::mutex m_lock;
 		std::map<int64_t, std::pair<call_return_t, void*>> m_cb;
 
+		// Functions
+		std::map<std::string, std::shared_ptr<ipc::collection>> m_classes;
+
 		// Threading
 		struct {
 			std::thread worker;
@@ -47,6 +51,17 @@ namespace ipc {
 		void worker();
 		void read_callback_init(os::error ec, size_t size);
 		void read_callback_msg(os::error ec, size_t size);
+		void handle_fnc_call();
+		void handle_fnc_reply();
+
+		private:
+		bool server_call_function(
+		    int64_t                  cid,
+		    std::string              cname,
+		    std::string              fname,
+		    std::vector<ipc::value>& args,
+		    std::vector<ipc::value>& rval,
+		    std::string&             errormsg);
 
 		public:
 		client(std::string socketPath);
@@ -57,6 +72,10 @@ namespace ipc {
 		bool call(std::string cname, std::string fname, std::vector<ipc::value> args, call_return_t fn, void* data, int64_t& cbid);
 
 		bool cancel(int64_t const& id);
+
+		public: // Functionality
+		bool register_collection(ipc::collection cls);
+		bool register_collection(std::shared_ptr<ipc::collection> cls);
 
 		// Temporary helper
 		std::vector<ipc::value> call_synchronous_helper(std::string cname, std::string fname, std::vector<ipc::value> args,

--- a/include/ipc-client.hpp
+++ b/include/ipc-client.hpp
@@ -32,7 +32,8 @@ namespace ipc {
 
 	class client {
 		std::unique_ptr<os::windows::named_pipe> m_socket;
-		std::shared_ptr<os::async_op> m_rop;
+		std::shared_ptr<os::async_op>			 m_wop, m_rop;
+		std::queue<std::vector<char>>            m_write_queue;
 
 		bool m_authenticated = false;
 		std::mutex m_lock;
@@ -45,12 +46,14 @@ namespace ipc {
 		struct {
 			std::thread worker;
 			bool stop = false;
-			std::vector<char> buf;
+			std::vector<char> readBuf;
+			std::vector<char> writeBuf;
 		} m_watcher;
 		
 		void worker();
 		void read_callback_init(os::error ec, size_t size);
 		void read_callback_msg(os::error ec, size_t size);
+		void write_callback(os::error ec, size_t size);	
 		void handle_fnc_call();
 		void handle_fnc_reply();
 

--- a/include/ipc-server.hpp
+++ b/include/ipc-server.hpp
@@ -33,6 +33,8 @@ namespace ipc {
 	typedef bool(*server_connect_handler_t)(void*, int64_t);
 	typedef void(*server_disconnect_handler_t)(void*, int64_t);
 	typedef void(*server_message_handler_t)(void*, int64_t, const std::vector<char>&);
+	typedef void (
+	    *server_client_broadcast_handler_t)(std::shared_ptr<os::windows::named_pipe>, const std::vector<ipc::value>&);
 
 	class server {
 		bool m_isInitialized = false;
@@ -51,9 +53,9 @@ namespace ipc {
 		std::map<std::shared_ptr<os::windows::named_pipe>, std::shared_ptr<server_instance>> m_clients;
 
 		// Event Handlers
-		std::pair<server_connect_handler_t, void*> m_handlerConnect;
-		std::pair<server_disconnect_handler_t, void*> m_handlerDisconnect;
-		std::pair<server_message_handler_t, void*> m_handlerMessage;
+		std::pair<server_connect_handler_t, void*>			m_handlerConnect;
+		std::pair<server_disconnect_handler_t, void*>		m_handlerDisconnect;
+		std::pair<server_message_handler_t, void*>			m_handlerMessage;
 
 		// Worker
 		struct {
@@ -91,10 +93,11 @@ namespace ipc {
 		    std::vector<ipc::value>						args,
 		    std::chrono::nanoseconds					timeout = 
 			std::chrono::milliseconds(15000));
-		std::vector<ipc::value> call_synchronous_broadcast_helper(
+		void call_synchronous_broadcast_helper(
 		    std::string              cname,
 		    std::string              fname,
 		    std::vector<ipc::value>  args,
+		    server_client_broadcast_handler_t clientCallback, 
 		    std::chrono::nanoseconds timeout = std::chrono::milliseconds(15000));
 
 		protected: // Client -> Server

--- a/include/ipc-server.hpp
+++ b/include/ipc-server.hpp
@@ -83,6 +83,20 @@ namespace ipc {
 		bool register_collection(ipc::collection cls);
 		bool register_collection(std::shared_ptr<ipc::collection> cls);
 
+		public: // Server -> Client(*) communication
+		std::vector<ipc::value> call_synchronous_helper(
+		    std::shared_ptr<os::windows::named_pipe>	client,
+		    std::string									cname,
+		    std::string									fname,
+		    std::vector<ipc::value>						args,
+		    std::chrono::nanoseconds					timeout = 
+			std::chrono::milliseconds(15000));
+		std::vector<ipc::value> call_synchronous_broadcast_helper(
+		    std::string              cname,
+		    std::string              fname,
+		    std::vector<ipc::value>  args,
+		    std::chrono::nanoseconds timeout = std::chrono::milliseconds(15000));
+
 		protected: // Client -> Server
 		bool client_call_function(int64_t cid, std::string cname, std::string fname,
 			std::vector<ipc::value>& args, std::vector<ipc::value>& rval, std::string& errormsg);

--- a/include/ipc-server.hpp
+++ b/include/ipc-server.hpp
@@ -33,8 +33,6 @@ namespace ipc {
 	typedef bool(*server_connect_handler_t)(void*, int64_t);
 	typedef void(*server_disconnect_handler_t)(void*, int64_t);
 	typedef void(*server_message_handler_t)(void*, int64_t, const std::vector<char>&);
-	typedef void (
-	    *server_client_broadcast_handler_t)(std::shared_ptr<os::windows::named_pipe>, const std::vector<ipc::value>&);
 
 	class server {
 		bool m_isInitialized = false;
@@ -86,7 +84,7 @@ namespace ipc {
 		bool register_collection(std::shared_ptr<ipc::collection> cls);
 
 		public: // Server -> Client(*) communication
-		std::vector<ipc::value> call_synchronous_helper(
+		void call_synchronous_helper(
 		    std::shared_ptr<os::windows::named_pipe>	client,
 		    std::string									cname,
 		    std::string									fname,
@@ -97,7 +95,6 @@ namespace ipc {
 		    std::string              cname,
 		    std::string              fname,
 		    std::vector<ipc::value>  args,
-		    server_client_broadcast_handler_t clientCallback, 
 		    std::chrono::nanoseconds timeout = std::chrono::milliseconds(15000));
 
 		protected: // Client -> Server

--- a/include/ipc.hpp
+++ b/include/ipc.hpp
@@ -54,7 +54,14 @@ namespace ipc {
 	};
 
 	namespace message {
+
+		bool is_function_call(std::vector<char>& buf, size_t offset);
+
 		struct function_call {
+			protected:
+			ipc::value magic = ipc::value(1);
+
+			public:
 			ipc::value uid = ipc::value(0ull);
 			ipc::value class_name = ipc::value("");
 			ipc::value function_name = ipc::value("");
@@ -66,6 +73,10 @@ namespace ipc {
 		};
 
 		struct function_reply {
+			protected:
+			ipc::value magic = ipc::value(-1);
+
+			public:
 			ipc::value uid = ipc::value(0ull);
 			std::vector<ipc::value> values;
 			ipc::value error = ipc::value("");

--- a/source/ipc-client.cpp
+++ b/source/ipc-client.cpp
@@ -118,6 +118,202 @@ void ipc::client::read_callback_msg(os::error ec, size_t size) {
 	ipc::log("(read) ????????: %.*s.", hex_msg.size(), hex_msg.data());
 #endif
 
+	bool is_fnc_call = ipc::message::is_function_call(m_watcher.buf, 0);
+	if (is_fnc_call) {
+		handle_fnc_call();
+	} else {
+		handle_fnc_reply();
+	}
+}
+
+void ipc::client::handle_fnc_call()
+{
+	std::vector<ipc::value>      proc_rval;
+	std::string                  proc_error;
+	ipc::message::function_call  fnc_call_msg;
+	ipc::message::function_reply fnc_reply_msg;
+	std::vector<char>            write_buffer;
+	bool                         success = false;
+	std::shared_ptr<os::async_op> write_op;
+
+#ifdef _DEBUG
+	ipc::log("????????: Authenticated Client, attempting deserialize of Function Call message.");
+#endif
+
+	try {
+		fnc_call_msg.deserialize(m_watcher.buf, 0);
+	} catch (std::exception e) {
+		ipc::log("????????: Deserialization of Function Call message failed with error %s.", e.what());
+		return;
+	}
+
+#ifdef _DEBUG
+	ipc::log(
+	    "%8llu: Function Call deserialized, class '%.*s' and function '%.*s', %llu arguments.",
+	    fnc_call_msg.uid.value_union.ui64,
+	    (uint64_t)fnc_call_msg.class_name.value_str.size(),
+	    fnc_call_msg.class_name.value_str.c_str(),
+	    (uint64_t)fnc_call_msg.function_name.value_str.size(),
+	    fnc_call_msg.function_name.value_str.c_str(),
+	    (uint64_t)fnc_call_msg.arguments.size());
+	for (size_t idx = 0; idx < fnc_call_msg.arguments.size(); idx++) {
+		ipc::value& arg = fnc_call_msg.arguments[idx];
+		switch (arg.type) {
+		case type::Int32:
+			ipc::log("\t%llu: %ld", idx, arg.value_union.i32);
+			break;
+		case type::Int64:
+			ipc::log("\t%llu: %lld", idx, arg.value_union.i64);
+			break;
+		case type::UInt32:
+			ipc::log("\t%llu: %lu", idx, arg.value_union.ui32);
+			break;
+		case type::UInt64:
+			ipc::log("\t%llu: %llu", idx, arg.value_union.ui64);
+			break;
+		case type::Float:
+			ipc::log("\t%llu: %f", idx, (double)arg.value_union.fp32);
+			break;
+		case type::Double:
+			ipc::log("\t%llu: %f", idx, arg.value_union.fp64);
+			break;
+		case type::String:
+			ipc::log("\t%llu: %.*s", idx, arg.value_str.size(), arg.value_str.c_str());
+			break;
+		case type::Binary:
+			ipc::log("\t%llu: (Binary)", idx);
+			break;
+		}
+	}
+#endif
+
+	// Execute
+	proc_rval.resize(0);
+	try {
+		success = server_call_function(
+		    -1, // Server
+		    fnc_call_msg.class_name.value_str,
+		    fnc_call_msg.function_name.value_str,
+		    fnc_call_msg.arguments,
+		    proc_rval,
+		    proc_error);
+	} catch (std::exception e) {
+		ipc::log(
+		    "%8llu: Unexpected exception during client call, error %s.", fnc_call_msg.uid.value_union.ui64, e.what());
+		throw e;
+	}
+
+	// Set
+	fnc_reply_msg.uid = fnc_call_msg.uid;
+	std::swap(proc_rval, fnc_reply_msg.values); // Fast "copy" of parameters.
+	if (!success) {
+		fnc_reply_msg.error = ipc::value(proc_error);
+	}
+
+#ifdef _DEBUG
+	ipc::log(
+	    "%8llu: FunctionCall Execute Complete, %llu return values",
+	    fnc_call_msg.uid.value_union.ui64,
+	    (uint64_t)fnc_reply_msg.values.size());
+	for (size_t idx = 0; idx < fnc_reply_msg.values.size(); idx++) {
+		ipc::value& arg = fnc_reply_msg.values[idx];
+		switch (arg.type) {
+		case type::Int32:
+			ipc::log("\t%llu: %ld", idx, arg.value_union.i32);
+			break;
+		case type::Int64:
+			ipc::log("\t%llu: %lld", idx, arg.value_union.i64);
+			break;
+		case type::UInt32:
+			ipc::log("\t%llu: %lu", idx, arg.value_union.ui32);
+			break;
+		case type::UInt64:
+			ipc::log("\t%llu: %llu", idx, arg.value_union.ui64);
+			break;
+		case type::Float:
+			ipc::log("\t%llu: %f", idx, (double)arg.value_union.fp32);
+			break;
+		case type::Double:
+			ipc::log("\t%llu: %f", idx, arg.value_union.fp64);
+			break;
+		case type::String:
+			ipc::log("\t%llu: %.*s", idx, arg.value_str.size(), arg.value_str.c_str());
+			break;
+		case type::Binary:
+			ipc::log("\t%llu: (Binary)", idx);
+			break;
+		}
+	}
+#endif
+
+	// Serialize
+	write_buffer.resize(fnc_reply_msg.size());
+	try {
+		fnc_reply_msg.serialize(write_buffer, 0);
+	} catch (std::exception e) {
+		ipc::log(
+		    "%8llu: Serialization of Function Reply message failed with error %s.",
+		    fnc_call_msg.uid.value_union.ui64,
+		    e.what());
+		return;
+	}
+
+#ifdef _DEBUG
+	ipc::log(
+	    "%8llu: Function Reply serialized, %llu bytes.",
+	    fnc_call_msg.uid.value_union.ui64,
+	    (uint64_t)write_buffer.size());
+	std::string hex_msg = ipc::vectortohex(write_buffer);
+	ipc::log("%8llu: %.*s.", fnc_call_msg.uid.value_union.ui64, hex_msg.size(), hex_msg.data());
+#endif
+
+	// TODO: This part needs some atention, it's different from the server code and doesn't have a decent
+	// write_op handling
+	if (write_buffer.size() != 0) {
+		ipc::make_sendable(m_watcher.buf, write_buffer);
+#ifdef _DEBUG
+		ipc::log("????????: Sending %llu bytes...", m_watcher.buf.size());
+		std::string hex_msg = ipc::vectortohex(m_watcher.buf);
+		ipc::log("????????: %.*s.", hex_msg.size(), hex_msg.data());
+#endif
+		os::error ec2 = m_socket->write(
+		    m_watcher.buf.data(),
+		    m_watcher.buf.size(),
+		    write_op,
+			nullptr);
+		if (ec2 != os::error::Success && ec2 != os::error::Pending) {
+			if (ec2 == os::error::Disconnected) {
+				return;
+			} else {
+				throw std::exception("Unexpected Error");
+			}
+		}
+
+		ec2 = write_op->wait(std::chrono::milliseconds(15000));
+		if (ec2 != os::error::Success) {
+			write_op->invalidate();
+			return;
+		}
+		write_op->invalidate();
+		
+	} else {
+#ifdef _DEBUG
+		ipc::log("????????: No Output, continuing as if nothing happened.");
+#endif
+		m_rop->invalidate();
+	}
+}
+
+void ipc::client::handle_fnc_reply()
+{
+	std::pair<call_return_t, void*> cb;
+	ipc::message::function_reply    fnc_reply_msg;
+
+	m_rop->invalidate();
+
+	// I need to check if this is a function_reply or a function_call, in case it's a function_call I need to call the method and answer the server
+	bool is_fnc_call = ipc::message::is_function_call(m_watcher.buf, 0);
+
 	try {
 		fnc_reply_msg.deserialize(m_watcher.buf, 0);
 	} catch (std::exception e) {
@@ -126,36 +322,37 @@ void ipc::client::read_callback_msg(os::error ec, size_t size) {
 	}
 
 #ifdef _DEBUG
-	ipc::log("(read) %8llu: Deserialized with %lld return values.", 
-		fnc_reply_msg.uid.value_union.ui64,
-		fnc_reply_msg.values.size());
+	ipc::log(
+	    "(read) %8llu: Deserialized with %lld return values.",
+	    fnc_reply_msg.uid.value_union.ui64,
+	    fnc_reply_msg.values.size());
 	for (size_t idx = 0; idx < fnc_reply_msg.values.size(); idx++) {
 		ipc::value& arg = fnc_reply_msg.values[idx];
 		switch (arg.type) {
-			case type::Int32:
-				ipc::log("(read) \t%llu: %ld", idx, arg.value_union.i32);
-				break;
-			case type::Int64:
-				ipc::log("(read) \t%llu: %lld", idx, arg.value_union.i64);
-				break;
-			case type::UInt32:
-				ipc::log("(read) \t%llu: %lu", idx, arg.value_union.ui32);
-				break;
-			case type::UInt64:
-				ipc::log("(read) \t%llu: %llu", idx, arg.value_union.ui64);
-				break;
-			case type::Float:
-				ipc::log("(read) \t%llu: %f", idx, (double)arg.value_union.fp32);
-				break;
-			case type::Double:
-				ipc::log("(read) \t%llu: %f", idx, arg.value_union.fp64);
-				break;
-			case type::String:
-				ipc::log("(read) \t%llu: %.*s", idx, arg.value_str.size(), arg.value_str.c_str());
-				break;
-			case type::Binary:
-				ipc::log("(read) \t%llu: (Binary)", idx);
-				break;
+		case type::Int32:
+			ipc::log("(read) \t%llu: %ld", idx, arg.value_union.i32);
+			break;
+		case type::Int64:
+			ipc::log("(read) \t%llu: %lld", idx, arg.value_union.i64);
+			break;
+		case type::UInt32:
+			ipc::log("(read) \t%llu: %lu", idx, arg.value_union.ui32);
+			break;
+		case type::UInt64:
+			ipc::log("(read) \t%llu: %llu", idx, arg.value_union.ui64);
+			break;
+		case type::Float:
+			ipc::log("(read) \t%llu: %f", idx, (double)arg.value_union.fp32);
+			break;
+		case type::Double:
+			ipc::log("(read) \t%llu: %f", idx, arg.value_union.fp64);
+			break;
+		case type::String:
+			ipc::log("(read) \t%llu: %.*s", idx, arg.value_str.size(), arg.value_str.c_str());
+			break;
+		case type::Binary:
+			ipc::log("(read) \t%llu: (Binary)", idx);
+			break;
 		}
 	}
 	ipc::log("(read) \terror: %.*s", fnc_reply_msg.error.value_str.size(), fnc_reply_msg.error.value_str.c_str());
@@ -163,7 +360,7 @@ void ipc::client::read_callback_msg(os::error ec, size_t size) {
 
 	// Find the callback function.
 	std::unique_lock<std::mutex> ulock(m_lock);
-	auto cb2 = m_cb.find(fnc_reply_msg.uid.value_union.ui64);
+	auto                         cb2 = m_cb.find(fnc_reply_msg.uid.value_union.ui64);
 	if (cb2 == m_cb.end()) {
 #ifdef _DEBUG
 		ipc::log("(read) %8llu: No callback, returning.", fnc_reply_msg.uid.value_union.ui64);
@@ -175,7 +372,7 @@ void ipc::client::read_callback_msg(os::error ec, size_t size) {
 	// Decode return values or errors.
 	if (fnc_reply_msg.error.value_str.size() > 0) {
 		fnc_reply_msg.values.resize(1);
-		fnc_reply_msg.values.at(0).type = ipc::type::Null;
+		fnc_reply_msg.values.at(0).type      = ipc::type::Null;
 		fnc_reply_msg.values.at(0).value_str = fnc_reply_msg.error.value_str;
 	}
 
@@ -193,6 +390,31 @@ void ipc::client::read_callback_msg(os::error ec, size_t size) {
 #ifdef _DEBUG
 	ipc::log("(read) %8llu: Done.", fnc_reply_msg.uid.value_union.ui64);
 #endif
+}
+
+bool ipc::client::server_call_function(
+    int64_t                  cid,
+    std::string              cname,
+    std::string              fname,
+    std::vector<ipc::value>& args,
+    std::vector<ipc::value>& rval,
+    std::string&             errormsg)
+{
+	if (m_classes.count(cname) == 0) {
+		errormsg = "Class '" + cname + "' is not registered.";
+		return false;
+	}
+	auto cls = m_classes.at(cname);
+
+	auto fnc = cls->get_function(fname, args);
+	if (!fnc) {
+		errormsg = "Function '" + fname + "' not found in class '" + cname + "'.";
+		return false;
+	}
+
+	fnc->call(cid, args, rval);
+
+	return true;
 }
 
 ipc::client::client(std::string socketPath) {
@@ -295,6 +517,20 @@ bool ipc::client::call(std::string cname, std::string fname, std::vector<ipc::va
 bool ipc::client::cancel(int64_t const& id) {
 	std::unique_lock<std::mutex> ulock(m_lock);
 	return m_cb.erase(id) != 0;
+}
+
+bool ipc::client::register_collection(ipc::collection cls)
+{
+	return register_collection(std::make_shared<ipc::collection>(cls));
+}
+
+bool ipc::client::register_collection(std::shared_ptr<ipc::collection> cls)
+{
+	if (m_classes.count(cls->get_name()) > 0)
+		return false;
+
+	m_classes.insert(std::make_pair(cls->get_name(), cls));
+	return true;
 }
 
 bool ipc::client::call(std::string cname, std::string fname, std::vector<ipc::value> args, call_return_t fn, void* data, int64_t& cbid) {

--- a/source/ipc-server-instance.cpp
+++ b/source/ipc-server-instance.cpp
@@ -210,7 +210,8 @@ void ipc::server_instance::read_callback_msg(os::error ec, size_t size) {
 		if (is_fnc_call) {
 			handle_fnc_call(write_buffer);
 		} else {
-			handle_fnc_reply();
+			// We don't handle function replies
+			// handle_fnc_reply();
 		}
 	}
 

--- a/source/ipc-server.cpp
+++ b/source/ipc-server.cpp
@@ -203,19 +203,54 @@ std::vector<ipc::value> ipc::server::call_synchronous_helper(
     std::vector<ipc::value>						args,
     std::chrono::nanoseconds					timeout)
 {
-	// TODO: To be implemented
+	auto& clientInfo = m_clients.find(client);
+	if (clientInfo == m_clients.end()) {
+		return {};
+	}
 
-	return {};
+	// Set up call reference data.
+	struct CallData
+	{
+		std::shared_ptr<os::windows::semaphore>        sgn    = std::make_shared<os::windows::semaphore>();
+		bool                                           called = false;
+		std::chrono::high_resolution_clock::time_point start  = std::chrono::high_resolution_clock::now();
+
+		std::vector<ipc::value> values;
+	} cd;
+
+	auto cb = [](const void* data, const std::vector<ipc::value>& rval) {
+		CallData& cd = const_cast<CallData&>(*static_cast<const CallData*>(data));
+
+		// This copies the data off of the reply thread to the main thread.
+		cd.values.reserve(rval.size());
+		std::copy(rval.begin(), rval.end(), std::back_inserter(cd.values));
+
+		cd.called = true;
+		cd.sgn->signal();
+	};
+
+	int64_t cbid    = 0;
+	bool    success = clientInfo->second->call(cname, fname, std::move(args), cb, &cd, cbid);
+	if (!success) {
+		return {};
+	}
+
+	cd.sgn->wait(timeout);
+	if (!cd.called) {
+		clientInfo->second->cancel(cbid);
+		return {};
+	}
+
+	return std::move(cd.values);
 }
 
-std::vector<ipc::value> ipc::server::call_synchronous_broadcast_helper(
-    std::string              cname,
-    std::string              fname,
-    std::vector<ipc::value>  args,
-    std::chrono::nanoseconds timeout)
+void ipc::server::call_synchronous_broadcast_helper(
+    std::string                       cname,
+    std::string                       fname,
+    std::vector<ipc::value>           args,
+    server_client_broadcast_handler_t clientCallback,
+    std::chrono::nanoseconds          timeout)
 {
-	// Probably use an input callback to handle each client return
-
 	// For each client
 	for (auto& client : m_clients)
 	{
@@ -243,19 +278,25 @@ std::vector<ipc::value> ipc::server::call_synchronous_broadcast_helper(
 		int64_t cbid    = 0;
 		bool    success = client.second->call(cname, fname, std::move(args), cb, &cd, cbid);
 		if (!success) {
-			return {};
+			if (clientCallback) {
+				clientCallback(client.first, {});
+			}
+			continue;
 		}
 
 		cd.sgn->wait(timeout);
 		if (!cd.called) {
 			client.second->cancel(cbid);
-			return {};
+			if (clientCallback) {
+				clientCallback(client.first, {});
+			}
+			continue;
+		}
+
+		if (clientCallback) {
+			clientCallback(client.first, cd.values);
 		}
 	}
-	
-	// return std::move(cd.values);
-
-	return {};
 }
 
 bool ipc::server::client_call_function(int64_t cid, std::string cname, std::string fname, std::vector<ipc::value>& args, std::vector<ipc::value>& rval, std::string& errormsg) {

--- a/source/ipc.cpp
+++ b/source/ipc.cpp
@@ -98,8 +98,21 @@ std::string ipc::vectortohex(const std::vector<char>& buf) {
 	return tohex.str();
 }
 
+bool ipc::message::is_function_call(std::vector<char>& buf, size_t offset)
+{
+	ipc::value magic = {};
+	magic.deserialize(buf, offset + sizeof(size_t));
+
+	if (magic.value_union.i32 == 1) {
+		return true;
+	}
+
+	return false;
+}
+
 size_t ipc::message::function_call::size() {
-	size_t size = sizeof(size_t)
+	size_t size = sizeof(size_t) 
+		+ magic.size()
 		+ uid.size() /* timestamp */
 		+ class_name.size()
 		+ function_name.size()
@@ -119,6 +132,7 @@ size_t ipc::message::function_call::serialize(std::vector<char>& buf, size_t off
 	reinterpret_cast<size_t&>(buf[noffset]) = size();
 	noffset += sizeof(size_t);
 
+	noffset += magic.serialize(buf, noffset);
 	noffset += uid.serialize(buf, noffset);
 	noffset += class_name.serialize(buf, noffset);
 	noffset += function_name.serialize(buf, noffset);
@@ -144,6 +158,7 @@ size_t ipc::message::function_call::deserialize(std::vector<char>& buf, size_t o
 	}
 	size_t noffset = offset + sizeof(size_t);
 
+	noffset += magic.deserialize(buf, noffset);
 	noffset += uid.deserialize(buf, noffset);
 	noffset += class_name.deserialize(buf, noffset);
 	noffset += function_name.deserialize(buf, noffset);
@@ -159,7 +174,8 @@ size_t ipc::message::function_call::deserialize(std::vector<char>& buf, size_t o
 }
 
 size_t ipc::message::function_reply::size() {
-	size_t size = sizeof(size_t)
+	size_t size = sizeof(size_t) 
+		+ magic.size()
 		+ uid.size() /* timestamp */
 		+ error.size() /* error */
 		+ sizeof(uint8_t) /* values */;
@@ -178,6 +194,7 @@ size_t ipc::message::function_reply::serialize(std::vector<char>& buf, size_t of
 	reinterpret_cast<size_t&>(buf[noffset]) = size();
 	noffset += sizeof(size_t);
 
+	noffset += magic.serialize(buf, noffset);
 	noffset += uid.serialize(buf, noffset);
 	noffset += error.serialize(buf, noffset);
 
@@ -201,6 +218,7 @@ size_t ipc::message::function_reply::deserialize(std::vector<char>& buf, size_t 
 	}
 	size_t noffset = offset + sizeof(size_t);
 
+	noffset += magic.deserialize(buf, noffset);
 	noffset += uid.deserialize(buf, noffset);
 	noffset += error.deserialize(buf, noffset);
 


### PR DESCRIPTION
Adds the possibility to run methods on clients as well. The API for registering and calling those methods are the same.

The only difference from the original Client-Server RPC is that the server will not wait for any client answer, neither the client will attempt to return something to the server, doing this the server will not stall (waiting for a delayed client answer or maybe indeterminately in case of deadlock).