### PR TITLE
Change the rval count variable from uint8_t to uint32_t

### DIFF
--- a/source/ipc-value.cpp
+++ b/source/ipc-value.cpp
@@ -62,7 +62,7 @@ ipc::value::value(float p_value) {
 }
 
 size_t ipc::value::size() {
-	size_t size = sizeof(uint8_t);
+	size_t size = sizeof(uint32_t);
 	switch (this->type) {
 		case type::Int32:
 			size += sizeof(int32_t);
@@ -101,8 +101,8 @@ size_t ipc::value::serialize(std::vector<char>& buf, size_t offset) {
 		throw std::exception("Value serialization failed, buffer too small");
 	}
 	size_t noffset = offset;
-	reinterpret_cast<uint8_t&>(buf[noffset]) = (uint8_t)this->type;
-	noffset += sizeof(uint8_t);
+	reinterpret_cast<uint32_t&>(buf[noffset]) = (uint32_t)this->type;
+	noffset += sizeof(uint32_t);
 	switch (this->type) {
 		case type::Int32:
 			reinterpret_cast<int32_t&>(buf[noffset]) = this->value_union.i32;
@@ -149,11 +149,11 @@ size_t ipc::value::serialize(std::vector<char>& buf, size_t offset) {
 }
 
 size_t ipc::value::deserialize(const std::vector<char>& buf, size_t offset) {
-	if ((buf.size() - offset) < sizeof(uint8_t)) {
+	if ((buf.size() - offset) < sizeof(uint32_t)) {
 		throw std::exception("Buffer too small");
 	}
 	this->type = (ipc::type)buf[offset];
-	size_t noffset = offset + sizeof(uint8_t);
+	size_t   noffset = offset + sizeof(uint32_t);
 	uint32_t length;
 	switch (this->type) {
 		case type::Int32:

--- a/source/ipc.cpp
+++ b/source/ipc.cpp
@@ -103,7 +103,7 @@ size_t ipc::message::function_call::size() {
 		+ uid.size() /* timestamp */
 		+ class_name.size()
 		+ function_name.size()
-		+ sizeof(uint8_t) /* arguments */;
+		+ sizeof(uint32_t) /* arguments */;
 	for (ipc::value& v : arguments) {
 		size += v.size();
 	}
@@ -123,8 +123,8 @@ size_t ipc::message::function_call::serialize(std::vector<char>& buf, size_t off
 	noffset += class_name.serialize(buf, noffset);
 	noffset += function_name.serialize(buf, noffset);
 
-	reinterpret_cast<uint8_t&>(buf[noffset]) = (uint8_t)arguments.size();
-	noffset += sizeof(uint8_t);
+	reinterpret_cast<uint32_t&>(buf[noffset]) = (uint32_t)arguments.size();
+	noffset += sizeof(uint32_t);
 
 	for (ipc::value& v : arguments) {
 		noffset += v.serialize(buf, noffset);
@@ -148,8 +148,8 @@ size_t ipc::message::function_call::deserialize(std::vector<char>& buf, size_t o
 	noffset += class_name.deserialize(buf, noffset);
 	noffset += function_name.deserialize(buf, noffset);
 
-	uint8_t cnt = reinterpret_cast<uint8_t&>(buf[noffset]);
-	noffset += sizeof(uint8_t);
+	uint32_t cnt = reinterpret_cast<uint32_t&>(buf[noffset]);
+	noffset += sizeof(uint32_t);
 	this->arguments.resize(cnt);
 	for (size_t idx = 0; idx < cnt; idx++) {
 		noffset += this->arguments[idx].deserialize(buf, noffset);
@@ -162,7 +162,7 @@ size_t ipc::message::function_reply::size() {
 	size_t size = sizeof(size_t)
 		+ uid.size() /* timestamp */
 		+ error.size() /* error */
-		+ sizeof(uint8_t) /* values */;
+		+ sizeof(uint32_t) /* values */;
 	for (ipc::value& v : values) {
 		size += v.size();
 	}
@@ -181,8 +181,8 @@ size_t ipc::message::function_reply::serialize(std::vector<char>& buf, size_t of
 	noffset += uid.serialize(buf, noffset);
 	noffset += error.serialize(buf, noffset);
 
-	reinterpret_cast<uint8_t&>(buf[noffset]) = (uint8_t)this->values.size();
-	noffset += sizeof(uint8_t);
+	reinterpret_cast<uint32_t&>(buf[noffset]) = (uint32_t)this->values.size();
+	noffset += sizeof(uint32_t);
 	for (ipc::value& v : values) {
 		noffset += v.serialize(buf, noffset);
 	}
@@ -204,8 +204,8 @@ size_t ipc::message::function_reply::deserialize(std::vector<char>& buf, size_t 
 	noffset += uid.deserialize(buf, noffset);
 	noffset += error.deserialize(buf, noffset);
 
-	uint8_t cnt = reinterpret_cast<uint8_t&>(buf[noffset]);
-	noffset += sizeof(uint8_t);
+	uint32_t cnt = reinterpret_cast<uint32_t&>(buf[noffset]);
+	noffset += sizeof(uint32_t);
 	this->values.resize(cnt);
 	for (size_t idx = 0; idx < cnt; idx++) {
 		noffset += this->values[idx].deserialize(buf, noffset);


### PR DESCRIPTION
Without this change the maximum number of elements returned is fixed on 256.
Instead using uint16_t the 32bit version was the choice because it is usually fast and more cache-friendly on most architectures.