### PR TITLE
Add options to register pre and post IPC callback methods

### DIFF
--- a/include/ipc-server.hpp
+++ b/include/ipc-server.hpp
@@ -25,6 +25,7 @@
 #include <queue>
 #include <string>
 #include <thread>
+#include <functional>
 #include "source/os/windows/named-pipe.hpp"
 
 namespace ipc {
@@ -33,8 +34,11 @@ namespace ipc {
 	typedef bool(*server_connect_handler_t)(void*, int64_t);
 	typedef void(*server_disconnect_handler_t)(void*, int64_t);
 	typedef void(*server_message_handler_t)(void*, int64_t, const std::vector<char>&);
+	typedef void(*server_pre_callback_t)(std::string, std::string, const std::vector<ipc::value>&, void*);
+	typedef void(*server_post_callback_t)(std::string, std::string, const std::vector<ipc::value>&, void*);
 
-	class server {
+	class server
+	{
 		bool m_isInitialized = false;
 
 		// Functions		
@@ -51,9 +55,11 @@ namespace ipc {
 		std::map<std::shared_ptr<os::windows::named_pipe>, std::shared_ptr<server_instance>> m_clients;
 
 		// Event Handlers
-		std::pair<server_connect_handler_t, void*> m_handlerConnect;
+		std::pair<server_connect_handler_t, void*>    m_handlerConnect;
 		std::pair<server_disconnect_handler_t, void*> m_handlerDisconnect;
-		std::pair<server_message_handler_t, void*> m_handlerMessage;
+		std::pair<server_message_handler_t, void*>    m_handlerMessage;
+		std::pair<server_pre_callback_t, void*>       m_preCallback;
+		std::pair<server_post_callback_t, void*>      m_postCallback;
 
 		// Worker
 		struct {
@@ -78,6 +84,8 @@ namespace ipc {
 		void set_connect_handler(server_connect_handler_t handler, void* data);
 		void set_disconnect_handler(server_disconnect_handler_t handler, void* data);
 		void set_message_handler(server_message_handler_t handler, void* data);
+		void set_pre_callback(server_pre_callback_t handler, void* data);
+		void set_post_callback(server_post_callback_t handler, void* data);
 
 		public: // Functionality
 		bool register_collection(ipc::collection cls);

--- a/include/ipc-server.hpp
+++ b/include/ipc-server.hpp
@@ -37,8 +37,7 @@ namespace ipc {
 	typedef void(*server_pre_callback_t)(std::string, std::string, const std::vector<ipc::value>&, void*);
 	typedef void(*server_post_callback_t)(std::string, std::string, const std::vector<ipc::value>&, void*);
 
-	class server
-	{
+	class server {
 		bool m_isInitialized = false;
 
 		// Functions		

--- a/source/ipc-server.cpp
+++ b/source/ipc-server.cpp
@@ -182,6 +182,14 @@ void ipc::server::set_message_handler(server_message_handler_t handler, void* da
 	m_handlerMessage = std::make_pair(handler, data);
 }
 
+void ipc::server::set_pre_callback(server_pre_callback_t handler, void* data) {
+	m_preCallback = std::make_pair(handler, data);
+}
+
+void ipc::server::set_post_callback(server_post_callback_t handler, void* data) {
+	m_postCallback = std::make_pair(handler, data);
+}
+
 bool ipc::server::register_collection(ipc::collection cls) {
 	return register_collection(std::make_shared<ipc::collection>(cls));
 }
@@ -207,7 +215,15 @@ bool ipc::server::client_call_function(int64_t cid, std::string cname, std::stri
 		return false;
 	}
 
+	if (m_preCallback.first) {
+		m_preCallback.first(cname, fname, args, m_preCallback.second);
+	}
+
 	fnc->call(cid, args, rval);
+
+	if (m_postCallback.first) {
+		m_postCallback.first(cname, fname, rval, m_postCallback.second);
+	}
 
 	return true;
 }


### PR DESCRIPTION
With this additions it's possible to do some pre-processing before actually calling the IPC method and right after returning from it, this way we can add log options and verify the integrity of all returning parameters.