### PR TITLE
fix: issues found with analyzer

### DIFF
--- a/include/ipc-client.hpp
+++ b/include/ipc-client.hpp
@@ -52,7 +52,7 @@ namespace ipc {
 		client(std::string socketPath);
 		virtual ~client();
 
-		bool call(std::string cname, std::string fname, std::vector<ipc::value> args, call_return_t fn, void* data, int64_t& cbid);
+		bool call(const std::string& cname, const std::string& fname, std::vector<ipc::value> args, call_return_t fn, void* data, int64_t& cbid);
 
 		bool cancel(int64_t const& id);
 

--- a/include/ipc-server.hpp
+++ b/include/ipc-server.hpp
@@ -83,7 +83,7 @@ namespace ipc {
 		bool register_collection(std::shared_ptr<ipc::collection> cls);
 
 		protected: // Client -> Server
-		bool client_call_function(int64_t cid, std::string cname, std::string fname,
+		bool client_call_function(int64_t cid, const std::string &cname, const std::string &fname,
 			std::vector<ipc::value>& args, std::vector<ipc::value>& rval, std::string& errormsg);
 
 		friend class server_instance;

--- a/include/ipc-value.hpp
+++ b/include/ipc-value.hpp
@@ -21,7 +21,7 @@
 #include <vector>
 
 namespace ipc {
-	enum class type {
+	enum class type : uint32_t{
 		Null,
 		Float,
 		Double,

--- a/source/ipc-client.cpp
+++ b/source/ipc-client.cpp
@@ -122,7 +122,7 @@ void ipc::client::read_callback_msg(os::error ec, size_t size) {
 
 	try {
 		fnc_reply_msg.deserialize(m_watcher.buf, 0);
-	} catch (std::exception e) {
+	} catch (std::exception& e) {
 		ipc::log("Deserialize failed with error %s.", e.what());
 		throw e;
 	}
@@ -157,6 +157,9 @@ void ipc::client::read_callback_msg(os::error ec, size_t size) {
 				break;
 			case type::Binary:
 				ipc::log("(read) \t%llu: (Binary)", idx);
+				break;
+			case type::Null:
+				ipc::log("(read) \t%llu: (Null)", idx);
 				break;
 		}
 	}
@@ -217,7 +220,7 @@ bool ipc::client::cancel(int64_t const& id) {
 	return m_cb.erase(id) != 0;
 }
 
-bool ipc::client::call(std::string cname, std::string fname, std::vector<ipc::value> args, call_return_t fn, void* data, int64_t& cbid) {
+bool ipc::client::call(const std::string& cname, const std::string& fname, std::vector<ipc::value> args, call_return_t fn, void* data, int64_t& cbid) {
 	static std::mutex mtx;
 	static uint64_t timestamp = 0;
 	os::error ec;
@@ -272,6 +275,9 @@ bool ipc::client::call(std::string cname, std::string fname, std::vector<ipc::va
 			case type::Binary:
 				ipc::log("(write) \t%llu: (Binary)", idx);
 				break;
+			case type::Null:
+				ipc::log("(write) \t%llu: (Null)", idx);
+				break;
 		}
 	}
 #endif
@@ -280,7 +286,7 @@ bool ipc::client::call(std::string cname, std::string fname, std::vector<ipc::va
 	std::vector<char> buf(fnc_call_msg.size());
 	try {
 		fnc_call_msg.serialize(buf, 0);
-	} catch (std::exception e) {
+	} catch (std::exception& e) {
 		ipc::log("(write) %8llu: Failed to serialize, error %s.", fnc_call_msg.uid.value_union.ui64, e.what());
 		throw e;
 	}

--- a/source/ipc-server-instance.cpp
+++ b/source/ipc-server-instance.cpp
@@ -161,14 +161,14 @@ void ipc::server_instance::read_callback_msg(os::error ec, size_t size) {
 	}
 
 	bool success = false;
-	
+
 #ifdef _DEBUG
 	ipc::log("????????: Authenticated Client, attempting deserialize of Function Call message.");
 #endif
 
 	try {
 		fnc_call_msg.deserialize(m_rbuf, 0);
-	} catch (std::exception e) {
+	} catch (std::exception & e) {
 		ipc::log("????????: Deserialization of Function Call message failed with error %s.", e.what());
 		return;
 	}
@@ -216,7 +216,7 @@ void ipc::server_instance::read_callback_msg(os::error ec, size_t size) {
 		success = m_parent->client_call_function(m_clientId,
 			fnc_call_msg.class_name.value_str, fnc_call_msg.function_name.value_str,
 			fnc_call_msg.arguments, proc_rval, proc_error);
-	} catch (std::exception e) {
+	} catch (std::exception & e) {
 		ipc::log("%8llu: Unexpected exception during client call, error %s.",
 			fnc_call_msg.uid.value_union.ui64, e.what());
 		throw e;
@@ -259,6 +259,9 @@ void ipc::server_instance::read_callback_msg(os::error ec, size_t size) {
 			case type::Binary:
 				ipc::log("\t%llu: (Binary)", idx);
 				break;
+			case type::Null:
+				ipc::log("\t%llu: Null", idx);
+				break;
 		}
 	}
 #endif
@@ -267,7 +270,7 @@ void ipc::server_instance::read_callback_msg(os::error ec, size_t size) {
 	write_buffer.resize(fnc_reply_msg.size());
 	try {
 		fnc_reply_msg.serialize(write_buffer, 0);
-	} catch (std::exception e) {
+	} catch (std::exception & e) {
 		ipc::log("%8llu: Serialization of Function Reply message failed with error %s.",
 			fnc_call_msg.uid.value_union.ui64, e.what());
 		return;

--- a/source/ipc-server.cpp
+++ b/source/ipc-server.cpp
@@ -127,12 +127,12 @@ void ipc::server::initialize(std::string socketPath) {
 				std::make_shared<os::windows::named_pipe>(os::create_only, socketPath, 255,
 					os::windows::pipe_type::Byte, os::windows::pipe_read_mode::Byte, false));
 		}
-	} catch (std::exception e) {
+	} catch (std::exception & e) {
 		throw e;
 	}
 
 	m_isInitialized = true;
-	m_socketPath = socketPath;
+	m_socketPath = std::move(socketPath);
 }
 
 void ipc::server::finalize() {
@@ -174,7 +174,7 @@ bool ipc::server::register_collection(std::shared_ptr<ipc::collection> cls) {
 	return true;
 }
 
-bool ipc::server::client_call_function(int64_t cid, std::string cname, std::string fname, std::vector<ipc::value>& args, std::vector<ipc::value>& rval, std::string& errormsg) {
+bool ipc::server::client_call_function(int64_t cid, const std::string & cname, const std::string &fname, std::vector<ipc::value>& args, std::vector<ipc::value>& rval, std::string& errormsg) {
 	if (m_classes.count(cname) == 0) {
 		errormsg = "Class '" + cname + "' is not registered.";
 		return false;

--- a/source/ipc-value.cpp
+++ b/source/ipc-value.cpp
@@ -23,12 +23,12 @@ ipc::value::value() {
 
 ipc::value::value(std::vector<char> p_value) {
 	this->type = type::Binary;
-	this->value_bin = p_value;
+	this->value_bin = std::move(p_value);
 }
 
 ipc::value::value(std::string p_value) {
 	this->type = type::String;
-	this->value_str = p_value;
+	this->value_str = std::move(p_value);
 }
 
 ipc::value::value(uint64_t p_value) {
@@ -149,17 +149,17 @@ size_t ipc::value::serialize(std::vector<char>& buf, size_t offset) {
 }
 
 size_t ipc::value::deserialize(const std::vector<char>& buf, size_t offset) {
-	if ((buf.size() - offset) < sizeof(uint32_t)) {
+	if (buf.size() < offset + sizeof(uint32_t)) {
 		throw std::exception("Buffer too small");
 	}
-	this->type = (ipc::type)buf[offset];
+	this->type = (ipc::type) *(reinterpret_cast<const uint32_t*>(&buf[offset]));
 	size_t   noffset = offset + sizeof(uint32_t);
 	uint32_t length;
 	switch (this->type) {
 		case type::Int32:
 		case type::UInt32:
 		case type::Float:
-			if ((buf.size() - noffset) < sizeof(int32_t)) {
+			if (buf.size() < noffset + sizeof(int32_t)) {
 				throw std::exception("Deserialize of 32-bit value failed");
 			}
 			memcpy(&this->value_union.i32, &buf[noffset], sizeof(int32_t));
@@ -168,19 +168,19 @@ size_t ipc::value::deserialize(const std::vector<char>& buf, size_t offset) {
 		case type::Int64:
 		case type::UInt64:
 		case type::Double:
-			if ((buf.size() - noffset) < sizeof(int64_t)) {
+			if (buf.size() < noffset + sizeof(int64_t)) {
 				throw std::exception("Deserialize of 64-bit value failed");
 			}
 			memcpy(&this->value_union.i64, &buf[noffset], sizeof(int64_t));
 			noffset += sizeof(int64_t);
 			break;
 		case type::String:
-			if ((buf.size() - noffset) < sizeof(uint32_t)) {
+			if (buf.size() < noffset + sizeof(uint32_t)) {
 				throw std::exception("Deserialize of string value failed, length missing");
 			}
 			length = reinterpret_cast<const uint32_t&>(buf[noffset]);
 			noffset += sizeof(uint32_t);
-			if ((buf.size() - noffset) < length) {
+			if (buf.size() < noffset + length) {
 				throw std::exception("Deserialize of string value failed, string missing");
 			}
 			this->value_str.clear();
@@ -191,12 +191,12 @@ size_t ipc::value::deserialize(const std::vector<char>& buf, size_t offset) {
 			noffset += length;
 			break;
 		case type::Binary:
-			if ((buf.size() - noffset) < sizeof(uint32_t)) {
+			if (buf.size() < noffset + sizeof(uint32_t)) {
 				throw std::exception("Deserialize of buffer value failed, length missing");
 			}
 			length = reinterpret_cast<const uint32_t&>(buf[noffset]);
 			noffset += sizeof(uint32_t);
-			if ((buf.size() - noffset) < length) {
+			if (buf.size() < noffset + length) {
 				throw std::exception("Deserialize of buffer value failed, buffer missing");
 			}
 			this->value_bin.clear();

--- a/source/ipc.cpp
+++ b/source/ipc.cpp
@@ -25,8 +25,8 @@ std::string ipc::base::make_unique_id(std::string name, std::vector<type> parame
 	// This behavior might not be desired, but allows some amount of flexibility.
 
 	std::string uq = name;
+	uq += "_";
 	if (parameters.size() > 0) {
-		uq += "_";
 		for (type p : parameters) {
 			switch (p) {
 				case ipc::type::Null:


### PR DESCRIPTION
fix few issues found with static code analyzer and some places what have catch by looking at code. 

some optimizations: with adding std::move() and changing functions params to references from values. Analyzer found more places where it can be applicable but it is relatively trivial fix and can be done later by separate PR when we need speedup code. 

Changes like this: 
`if ((buf.size() - noffset) < sizeof(int64_t)) {`
`if (buf.size() < noffset + sizeof(uint32_t)) {`
Here if 'noffset' somehow become bigger than buf.size() then subtractions result be some huge number as both values is unsigned size_t.

`uq += "_";` moved out of `if (parameters.size() > 0) {` as two functions can create conflicting ids. 
`test(int ) -> test_I4`
`test_I4()  -> test_I4`
