### PR TITLE
cppcheck warnings cleanup

### DIFF
--- a/include/ipc-class.hpp
+++ b/include/ipc-class.hpp
@@ -25,7 +25,7 @@
 namespace ipc {
 	class collection {
 		public:
-		collection(std::string name);
+		collection(const std::string & name);
 		virtual ~collection();
 
 		std::string get_name();

--- a/include/ipc-client.hpp
+++ b/include/ipc-client.hpp
@@ -56,6 +56,6 @@ namespace ipc {
 
 		bool cancel(int64_t const& id);
 
-		std::vector<ipc::value> call_synchronous_helper(std::string cname, std::string fname, std::vector<ipc::value> args);
+		std::vector<ipc::value> call_synchronous_helper(const std::string & cname, const std::string &fname, const std::vector<ipc::value> & args);
 	};
 }

--- a/include/ipc-function.hpp
+++ b/include/ipc-function.hpp
@@ -25,14 +25,14 @@ namespace ipc {
 
 	class function {
 		public:
-		function(std::string name, std::vector<ipc::type> params, call_handler_t ptr, void* data);
-		function(std::string name, std::vector<ipc::type> params, call_handler_t ptr);
-		function(std::string name, std::vector<ipc::type> params, void* data);
-		function(std::string name, std::vector<ipc::type> params);
-		function(std::string name, call_handler_t ptr, void* data);
-		function(std::string name, call_handler_t ptr);
-		function(std::string name, void* data);
-		function(std::string name);
+		function(const std::string & name, const std::vector<ipc::type>& params, call_handler_t ptr, void* data);
+		function(const std::string & name, const std::vector<ipc::type>& params, call_handler_t ptr);
+		function(const std::string & name, const std::vector<ipc::type>& params, void* data);
+		function(const std::string & name, const std::vector<ipc::type>& params);
+		function(const std::string & name, call_handler_t ptr, void* data);
+		function(const std::string & name, call_handler_t ptr);
+		function(const std::string & name, void* data);
+		function(const std::string & name);
 		virtual ~function();
 
 		/** Get the unique name for this function used to identify it.

--- a/include/ipc-value.hpp
+++ b/include/ipc-value.hpp
@@ -53,8 +53,8 @@ namespace ipc {
 		value(int64_t);
 		value(uint32_t);
 		value(uint64_t);
-		value(std::string);
-		value(std::vector<char>);
+		value(const std::string & p_value);
+		value(const std::vector<char>& p_value);
 
 		size_t size();
 		size_t serialize(std::vector<char>& buf, size_t offset);

--- a/include/ipc.hpp
+++ b/include/ipc.hpp
@@ -47,7 +47,7 @@ namespace ipc {
 
 	class base {
 		public:
-		static std::string make_unique_id(std::string name, std::vector<type> parameters);
+		static std::string make_unique_id(const std::string & name, const std::vector<type>& parameters);
 		
 	};
 

--- a/source/ipc-class.cpp
+++ b/source/ipc-class.cpp
@@ -17,8 +17,8 @@
 
 #include "ipc-class.hpp"
 
-ipc::collection::collection(std::string name) {
-	this->m_name = name;
+ipc::collection::collection(const std::string & name): m_name(name) {
+
 }
 
 ipc::collection::~collection() {

--- a/source/ipc-client.cpp
+++ b/source/ipc-client.cpp
@@ -323,7 +323,7 @@ bool ipc::client::call(std::string cname, std::string fname, std::vector<ipc::va
 	return true;
 }
 
-std::vector<ipc::value> ipc::client::call_synchronous_helper(std::string cname, std::string fname, std::vector<ipc::value> args) {
+std::vector<ipc::value> ipc::client::call_synchronous_helper(const std::string & cname, const std::string & fname, const std::vector<ipc::value>& args) {
 	// Set up call reference data.
 	struct CallData {
 		std::shared_ptr<os::windows::semaphore> sgn = std::make_shared<os::windows::semaphore>();

--- a/source/ipc-function.cpp
+++ b/source/ipc-function.cpp
@@ -19,7 +19,7 @@
 #include "ipc.hpp"
 
 
-ipc::function::function(std::string name, std::vector<ipc::type> params, call_handler_t ptr, void* data) {
+ipc::function::function(const std::string & name, const std::vector<ipc::type>& params, call_handler_t ptr, void* data) {
 	this->m_name = name;
 	this->m_nameUnique = ipc::base::make_unique_id(m_name, params);
 	this->m_params = params;
@@ -27,25 +27,25 @@ ipc::function::function(std::string name, std::vector<ipc::type> params, call_ha
 	this->m_callHandler.second = data;
 }
 
-ipc::function::function(std::string name, std::vector<ipc::type> params, call_handler_t ptr)
+ipc::function::function(const std::string & name, const std::vector<ipc::type>& params, call_handler_t ptr)
 	: function(name, params, ptr, nullptr) {}
 
-ipc::function::function(std::string name, std::vector<ipc::type> params, void* data)
+ipc::function::function(const std::string & name, const std::vector<ipc::type>& params, void* data)
 	: function(name, params, nullptr, data) {}
 
-ipc::function::function(std::string name, std::vector<ipc::type> params)
+ipc::function::function(const std::string & name, const std::vector<ipc::type>& params)
 	: function(name, params, nullptr, nullptr) {}
 
-ipc::function::function(std::string name, call_handler_t ptr, void* data)
+ipc::function::function(const std::string & name, call_handler_t ptr, void* data)
 	: function(name, std::vector<ipc::type>(), ptr, data) {}
 
-ipc::function::function(std::string name, call_handler_t ptr)
+ipc::function::function(const std::string & name, call_handler_t ptr)
 	: function(name, std::vector<ipc::type>(), ptr, nullptr) {}
 
-ipc::function::function(std::string name, void* data)
+ipc::function::function(const std::string & name, void* data)
 	: function(name, std::vector<ipc::type>(), nullptr, data) {}
 
-ipc::function::function(std::string name)
+ipc::function::function(const std::string & name)
 	: function(name, std::vector<ipc::type>(), nullptr, nullptr) {}
 
 ipc::function::~function() {}

--- a/source/ipc-server-instance.cpp
+++ b/source/ipc-server-instance.cpp
@@ -26,12 +26,11 @@ using namespace std::placeholders;
 
 ipc::server_instance::server_instance() {}
 
-ipc::server_instance::server_instance(ipc::server* owner, std::shared_ptr<os::windows::named_pipe> conn) {
-	m_parent = owner;
-	m_socket = conn;
-	m_clientId = 0;
-
-	m_stopWorkers = false;
+ipc::server_instance::server_instance(ipc::server* owner, std::shared_ptr<os::windows::named_pipe> conn): 
+	m_stopWorkers(0),
+	m_socket(conn),
+	m_parent(owner),
+	m_clientId(0) {
 	m_worker = std::thread(std::bind(&server_instance::worker, this));
 }
 

--- a/source/ipc-value.cpp
+++ b/source/ipc-value.cpp
@@ -21,14 +21,10 @@ ipc::value::value() {
 	this->type = type::Null;
 }
 
-ipc::value::value(std::vector<char> p_value) {
-	this->type = type::Binary;
-	this->value_bin = p_value;
+ipc::value::value(const std::vector<char>& p_value):type(type::Binary), value_bin(p_value) {
 }
 
-ipc::value::value(std::string p_value) {
-	this->type = type::String;
-	this->value_str = p_value;
+ipc::value::value(const std::string & p_value):type(type::String), value_str(p_value) {
 }
 
 ipc::value::value(uint64_t p_value) {

--- a/source/ipc.cpp
+++ b/source/ipc.cpp
@@ -18,7 +18,7 @@
 #include "ipc.hpp"
 #include <sstream>
 
-std::string ipc::base::make_unique_id(std::string name, std::vector<type> parameters) {
+std::string ipc::base::make_unique_id(const std::string& name, const std::vector<type> & parameters) {
 	// Implement similar behavior to C/C++ compilers, which put parameter type
 	//  into the generated function name in order to allow overloading of the
 	//  same function, even when exported.

--- a/source/windows/async_request.cpp
+++ b/source/windows/async_request.cpp
@@ -50,8 +50,8 @@ void *os::windows::async_request::get_waitable() {
 }
 
 os::windows::async_request::~async_request() {
-	if (is_valid()) {
-		cancel();
+	if (os::windows::async_request::is_valid()) {
+		os::windows::async_request::cancel();
 	}
 }
 

--- a/source/windows/async_request.hpp
+++ b/source/windows/async_request.hpp
@@ -40,7 +40,7 @@ namespace os {
 			static void completion_routine(DWORD dwErrorCode, DWORD dwBytesTransmitted, LPVOID ov);
 
 			public:
-			~async_request();
+			virtual ~async_request();
 
 			virtual bool is_valid() override;
 

--- a/source/windows/named-pipe.cpp
+++ b/source/windows/named-pipe.cpp
@@ -140,7 +140,7 @@ os::windows::named_pipe::named_pipe() {
 	set_connected(false);
 }
 
-os::windows::named_pipe::named_pipe(os::create_only_t, std::string name,
+os::windows::named_pipe::named_pipe(os::create_only_t, const std::string & name,
 									size_t         max_instances /*= PIPE_UNLIMITED_INSTANCES*/,
 									pipe_type      type /*= pipe_type::Message*/,
 									pipe_read_mode mode /*= pipe_read_mode::Message*/, bool is_unique /*= false*/)
@@ -152,7 +152,7 @@ os::windows::named_pipe::named_pipe(os::create_only_t, std::string name,
 	created = true;
 }
 
-os::windows::named_pipe::named_pipe(os::open_only_t, std::string name,
+os::windows::named_pipe::named_pipe(os::open_only_t, const std::string & name,
 									pipe_read_mode mode /*= pipe_read_mode::Message*/)
 	: named_pipe() {
 	validate_open_param(name);

--- a/source/windows/named-pipe.hpp
+++ b/source/windows/named-pipe.hpp
@@ -61,10 +61,10 @@ namespace os {
 			void handle_accept_callback(os::error code, size_t length);
 
 			public:
-			named_pipe(os::create_only_t, std::string name, size_t max_instances = PIPE_UNLIMITED_INSTANCES,
+			named_pipe(os::create_only_t, const std::string & name, size_t max_instances = PIPE_UNLIMITED_INSTANCES,
 					   pipe_type type = pipe_type::Message, pipe_read_mode mode = pipe_read_mode::Message,
 					   bool is_unique = false);
-			named_pipe(os::open_only_t, std::string name, pipe_read_mode mode = pipe_read_mode::Message);
+			named_pipe(os::open_only_t, const std::string & name, pipe_read_mode mode = pipe_read_mode::Message);
 			~named_pipe();
 
 			os::error read(char *buffer, size_t buffer_length, std::shared_ptr<os::async_op> &op, os::async_op_cb_t cb);


### PR DESCRIPTION
It was mostly warnings for "const ref functions params" and "constructor initialization order". 