### PR TITLE
some fix  v140_xp build

### DIFF
--- a/source/windows/async_request.hpp
+++ b/source/windows/async_request.hpp
@@ -37,7 +37,7 @@ namespace os {
 
 			void set_valid(bool valid);
 
-			static void completion_routine(DWORD dwErrorCode, DWORD dwBytesTransmitted, LPVOID ov);
+			static void CALLBACK completion_routine(DWORD dwErrorCode, DWORD dwBytesTransmitted, LPVOID ov);
 
 			public:
 			~async_request();


### PR DESCRIPTION
Build : Win32
SDK: Windows SDK 7.1A
calling faild WaitForSingleObjectEx

예외 발생(0x00BA5B2C, xxx.exe): 0xC0000005: 0x00BA5B2C 위치를 실행하는 동안 액세스 위반이 발생했습니다..
xxx.exe: 0xC0000005: Access violation reading location 0x00BA5B2C

https://github.com/stream-labs/lib-streamlabs-ipc/blob/1f41876853f4475cb2be697eafa91f74d3e8553a/source/windows/waitable.cpp#L36

https://msdn.microsoft.com/en-us/library/windows/desktop/aa364052%28v=vs.85%29.aspx?f=255&MSPPError=-2147217396
VOID CALLBACK FileIOCompletionRoutine(
  _In_    DWORD        dwErrorCode,
  _In_    DWORD        dwNumberOfBytesTransfered,
  _Inout_ LPOVERLAPPED lpOverlapped
);