### PR TITLE
Remove the try-catch block when calling a method on the server

### DIFF
--- a/source/ipc-server-instance.cpp
+++ b/source/ipc-server-instance.cpp
@@ -212,15 +212,9 @@ void ipc::server_instance::read_callback_msg(os::error ec, size_t size) {
 
 	// Execute
 	proc_rval.resize(0);
-	try {
-		success = m_parent->client_call_function(m_clientId,
-			fnc_call_msg.class_name.value_str, fnc_call_msg.function_name.value_str,
-			fnc_call_msg.arguments, proc_rval, proc_error);
-	} catch (std::exception & e) {
-		ipc::log("%8llu: Unexpected exception during client call, error %s.",
-			fnc_call_msg.uid.value_union.ui64, e.what());
-		throw e;
-	}
+	success = m_parent->client_call_function(m_clientId,
+		fnc_call_msg.class_name.value_str, fnc_call_msg.function_name.value_str,
+		fnc_call_msg.arguments, proc_rval, proc_error);
 
 	// Set
 	fnc_reply_msg.uid = fnc_call_msg.uid;


### PR DESCRIPTION
Remove the try-catch block when calling a method on the server.
This was (sometimes) occluding the callstack for some crash reports (see Asana ticket https://app.asana.com/0/734357654754972/1107505184397285/f)

