### PR TITLE
ipc::server::kill_client call order

### DIFF
--- a/source/ipc-server.cpp
+++ b/source/ipc-server.cpp
@@ -124,10 +124,13 @@ void ipc::server::spawn_client(std::shared_ptr<ipc::socket> socket) {
 }
 
 void ipc::server::kill_client(std::shared_ptr<ipc::socket> socket) {
+	// First, destroy the server instance.
+	// This will wait for currently executing requests to be finished.
+	m_clients.erase(socket);
+	// Then notify the consumer about the disconnection.
 	if (m_handlerDisconnect.first) {
 		m_handlerDisconnect.first(m_handlerDisconnect.second, 0);
-	}
-	m_clients.erase(socket);
+	}	
 }
 #endif
 


### PR DESCRIPTION
### Description
This PR changes function call order in `ipc::server::kill_client`. Now, first, it finishes all operations for the disconnected client and destroys the server instance. Then, it notifies a library consumer about the disconnection.

### Motivation and Context
Currently, the `kill_client` implementation notifies a consumer about disconnection, then destroys the server instance which may take a long time in case if the server instance has not finished executing the disconnected client requests. This behavior confuses the consumer and increases the likelihood of incorrect behavior. There is not a graceful way to forcely stop executing the client requests. The functions like TerminateThread may lead to memory leaks, incorrect API state, etc.

### How Has This Been Tested?
This was tested as a part of **obs-studio-node** with an **artificial sleep** which delayed `obs_reset_video`.

**First Test**
1. Start Streamlabs Desktop.
2. Stop it by Alt+F4/Task Manager kill.
3. Click the No button in the dialog
4. The obs64.exe process will still be in the memory.
5. Wait for 10-15 seconds
6. There should not be any crash notification (the old version would crash).

**Second Test**
1. Open Task Manager, scroll to processes which start with "o".
2. Start Streamlabs Desktop
3. Memorize obs64.exe PID (via Task Manager).
4. Stop Streamlabs Desktop by Alt+F4/Task Manager kill.
5. Click the No button in the dialog
6. The process will still be in the memory.
8. Start Streamlabs Desktop **again**
9. obs64.exe PID should change (in Task Manager)

You will not be able to do the test without the artificial sleep or a test machine with a very slow Streamlabs Desktop initialization.

### Checklist:
- [x] The code has been tested.
