### PR TITLE
ipc::server::kill_client call order for macOS

### DIFF
--- a/source/ipc-server.cpp
+++ b/source/ipc-server.cpp
@@ -148,10 +148,10 @@ void ipc::server::spawn_client(std::shared_ptr<ipc::socket> socket) {
 }
 
 void ipc::server::kill_client(std::shared_ptr<ipc::socket> socket) {
+	m_clients.erase(socket);
 	if (m_handlerDisconnect.first) {
 		m_handlerDisconnect.first(m_handlerDisconnect.second, 0);
 	}
-	m_clients.erase(socket);
 }
 #endif
 


### PR DESCRIPTION
### Description
Changed functions calls order inside ipc::server::kill_client for macOS (see #38).

### Motivation and Context
See #38.

### How Has This Been Tested?
Compiled, started/stopped Streamlabs Desktop on macOS. No crashes or other issues.

### Checklist:
- [x] The code has been tested.