### PR TITLE
Disconnection callback

### DIFF
--- a/include/ipc-client.hpp
+++ b/include/ipc-client.hpp
@@ -17,6 +17,7 @@
 ******************************************************************************/
 
 #pragma once
+#include <functional>
 #include <string>
 #include <memory>
 #include "ipc.hpp"
@@ -32,9 +33,25 @@ typedef void (*call_on_freez_t)(bool freez_detected, std::string app_state_path,
 namespace ipc {
 	class client {
 		public:
+		
+		using call_on_disconnect_t = std::function<void()>;
+		
+		// |disconnectionCallback| is called when the server disconnection is detected.
+		// If the callback is not set or you use the other constructor,
+		// the client will just call |exit(1)| when the server disconnects.
+		static std::shared_ptr<client> create(
+			const std::string& socketPath,
+			call_on_disconnect_t disconnectionCallback);
+
 		static std::shared_ptr<client> create(std::string socketPath);
 		client() {};
 		virtual ~client() {};
+
+		// Stop all internal threads and the background disconnection detection.
+		// Call this if you do not plan to use the object anymore
+		// but also do not want to completely destroy it.
+		// The destructor will call the method anyways.
+		virtual void stop() = 0;
 
 		virtual bool call(
 		    const std::string&      cname,

--- a/source/apple/ipc-client-osx.cpp
+++ b/source/apple/ipc-client-osx.cpp
@@ -4,6 +4,11 @@ call_return_t g_fn   = NULL;
 void*         g_data = NULL;
 int64_t       g_cbid = NULL;
 
+std::shared_ptr<ipc::client> ipc::client::create(const std::string& socketPath, call_on_disconnect_t) {
+	// There is not a worker thread on macOS, so we do not care about the disconnection callback.
+	return std::make_unique<ipc::client_osx>(socketPath);
+}
+
 std::shared_ptr<ipc::client> ipc::client::create(std::string socketPath) {
 	return std::make_unique<ipc::client_osx>(socketPath);
 }
@@ -16,12 +21,20 @@ ipc::client_osx::client_osx(std::string socketPath) {
 	m_writer_sem = sem_open(writer_sem_name.c_str(), O_CREAT | O_EXCL, 0644, 1);
 
 	buffer.resize(130000);
+
+	m_stop = false;
 }
 
 ipc::client_osx::~client_osx() {
-	sem_post(m_writer_sem);
-	sem_close(m_writer_sem);
-	m_socket = nullptr;
+	stop();
+}
+
+void ipc::client_win::stop() {
+	if (!m_stop.exchange(true)) {
+		sem_post(m_writer_sem);
+		sem_close(m_writer_sem);
+		m_socket = nullptr;
+	}
 }
 
 bool ipc::client_osx::call(

--- a/source/apple/ipc-client-osx.cpp
+++ b/source/apple/ipc-client-osx.cpp
@@ -29,7 +29,7 @@ ipc::client_osx::~client_osx() {
 	stop();
 }
 
-void ipc::client_win::stop() {
+void ipc::client_osx::stop() {
 	if (!m_stop.exchange(true)) {
 		sem_post(m_writer_sem);
 		sem_close(m_writer_sem);

--- a/source/apple/ipc-client-osx.hpp
+++ b/source/apple/ipc-client-osx.hpp
@@ -3,6 +3,7 @@
 #include "ipc-socket-osx.hpp"
 #include "async_request.hpp"
 
+#include <atomic>
 #include <mutex>
 #include <map>
 #include <semaphore.h>
@@ -16,6 +17,9 @@ namespace ipc {
 		    ~client_osx();
 
         public:
+
+            void stop() override;
+
             virtual bool call(
                 const std::string&      cname,
                 const std::string&      fname,
@@ -32,6 +36,7 @@ namespace ipc {
             ) override;
 
         private:
+        std::atomic_bool m_stop = true;
         std::unique_ptr<os::apple::socket_osx> m_socket;
         std::string writer_sem_name = "semaphore-client-writer";
 		sem_t *m_writer_sem;

--- a/source/windows/ipc-client-win.cpp
+++ b/source/windows/ipc-client-win.cpp
@@ -25,14 +25,14 @@ std::shared_ptr<ipc::client> ipc::client::create(std::string socketPath) {
 ipc::client_win::client_win(
 	const std::string& socketPath,
 	call_on_disconnect_t disconnectionCallback)
-: m_socketPath(socketPath)
-, m_disconnectionCallback(disconnectionCallback)
+	: m_socketPath(socketPath)
+	, m_disconnectionCallback(disconnectionCallback)
 {
 	start();
 }
 
 ipc::client_win::client_win(std::string socketPath)
-: m_socketPath(socketPath)
+	: m_socketPath(socketPath)
 {
 	start();
 }

--- a/source/windows/ipc-client-win.cpp
+++ b/source/windows/ipc-client-win.cpp
@@ -25,7 +25,8 @@ std::shared_ptr<ipc::client> ipc::client::create(std::string socketPath) {
 ipc::client_win::client_win(
 	const std::string& socketPath,
 	call_on_disconnect_t disconnectionCallback)
-: m_socketPath(socketPath), m_disconnectionCallback(disconnectionCallback)
+: m_socketPath(socketPath)
+, m_disconnectionCallback(disconnectionCallback)
 {
 	start();
 }

--- a/source/windows/ipc-client-win.hpp
+++ b/source/windows/ipc-client-win.hpp
@@ -2,16 +2,23 @@
 #include "../include/error.hpp"
 #include "ipc-socket-win.hpp"
 
+#include <atomic>
 #include <mutex>
 #include <map>
 
 namespace ipc {
 	class client_win : public ipc::client {
         public:
+
+            client_win(const std::string& socketPath, call_on_disconnect_t disconnectionCallback);
             client_win(std::string socketPath);
 		    ~client_win();
 
         public:
+
+            void start();
+            void stop() override;
+
             virtual bool call(
                 const std::string&      cname,
                 const std::string&      fname,
@@ -28,6 +35,8 @@ namespace ipc {
             ) override;
 
         private:
+		    std::string m_socketPath;
+		    call_on_disconnect_t m_disconnectionCallback;
 		    std::unique_ptr<os::windows::socket_win> m_socket;
 		    std::shared_ptr<os::async_op> m_rop;
 
@@ -39,7 +48,7 @@ namespace ipc {
 		    struct
 		    {
 			    std::thread       worker;
-			    bool              stop = false;
+			    std::atomic_bool  stop = true;
 			    std::vector<char> buf;
 		    } m_watcher;
 


### PR DESCRIPTION
### Description
- Adds a new `ipc::client` constructor which allows a consumer to specify a callback function which will be called when an internal ipc::client_win thread detects server disconnection.
- Adds a new method `ipc::client::stop()` which allows to stop internal client threads before the client object is destroyed.

The changes are backward compatible. The old constructor is still there. The `ipc::client::stop()` is called in the destructor and stops everything if it has not been stopped yet.

### Motivation and Context
The old code of `ipc::client_win::worker` just calls exit() at the end if the server is disconnected. This behavior breaks normal exiting of Streamlabs Desktop which causes a freeze which actually is not even seen by user until they go to Task Manager. Overall, the library should not decide for the whole application if it exits or not. So we add an option to move the decision to the consumer.

### How Has This Been Tested?
Tested compilation on both Windows and macOS. Added temporary debug logs and tested that all the methods are called in the correct order. Tested with new obs-studio-node (the PR will be later) to check if the fix works for the consumer. Anyway, QA tests will be necessary.

### Types of changes
A bug fix/an improvement which fixes a consumer issue.

### Checklist:
- [X] The code has been tested.
