### PR TITLE
Removed exit(1) from ipc::client_win::worker

### DIFF
--- a/source/windows/ipc-client-win.cpp
+++ b/source/windows/ipc-client-win.cpp
@@ -232,8 +232,6 @@ void ipc::client_win::worker() {
 	if (!m_socket->is_connected()) {
 		if (m_disconnectionCallback) {
 			m_disconnectionCallback();
-		} else {
-			exit(1);
 		}
 	}
 }


### PR DESCRIPTION
### Description
An easy fix to avoid merging the [1152 obs-studio-node](https://github.com/stream-labs/obs-studio-node/pull/1152) pull request.

### Motivation and Context
1. The client correctly asks the server to shutdown.
2. The server executes the request.
3. The client IPC thread (as a part of the worker window process) terminates and calls exit(1) because the server disconnected.
4. The other UI processes stay in memory because they wait for a signal from the worker window process.
5. A user cannot start Streamlabs Desktop again.

### How Has This Been Tested?
Tested compilation on Windows.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] The code has been tested.
