### PR TITLE
add watchdog to monitor for too long ipc calls

### DIFF
--- a/ci/check-format.sh
+++ b/ci/check-format.sh
@@ -52,3 +52,5 @@ find . -type d \( \
     -name '*.c' -or \
     -name '*.cpp' \
  | xargs -L100 -P ${NPROC} "${CLANG_FORMAT}" ${VERBOSITY} -i -style=file -fallback-style=none
+
+git diff

--- a/include/ipc-server-instance.hpp
+++ b/include/ipc-server-instance.hpp
@@ -25,7 +25,7 @@ class server;
 
 class server_instance {
 public:
-	static std::shared_ptr<ipc::server_instance> create(server *owner, std::shared_ptr<ipc::socket> socket, bool activate_watchdog);
+	static std::shared_ptr<ipc::server_instance> create(server *owner, std::shared_ptr<ipc::socket> socket, int call_timeout);
 	server_instance(){};
 	virtual ~server_instance(){};
 };

--- a/include/ipc-server-instance.hpp
+++ b/include/ipc-server-instance.hpp
@@ -25,7 +25,7 @@ class server;
 
 class server_instance {
 public:
-	static std::shared_ptr<ipc::server_instance> create(server *owner, std::shared_ptr<ipc::socket> socket);
+	static std::shared_ptr<ipc::server_instance> create(server *owner, std::shared_ptr<ipc::socket> socket, bool activate_watchdog);
 	server_instance(){};
 	virtual ~server_instance(){};
 };

--- a/include/ipc-server.hpp
+++ b/include/ipc-server.hpp
@@ -52,7 +52,7 @@ class server {
 	std::list<std::shared_ptr<ipc::socket>> m_sockets;
 #endif
 	std::string m_socketPath = "";
-	bool m_activateWatchdog = false;
+	int m_callTimeout = 0;
 
 	// Client management.
 	std::mutex m_clients_mtx;
@@ -97,7 +97,7 @@ public:
 public: // Status
 	void initialize(std::string socketPath);
 	void finalize();
-	void set_watchdog(bool activateWatchdog);
+	void set_call_timeout(int callTimeout);
 
 public: // Events
 	void set_connect_handler(server_connect_handler_t handler, void *data);

--- a/include/ipc-server.hpp
+++ b/include/ipc-server.hpp
@@ -52,6 +52,7 @@ class server {
 	std::list<std::shared_ptr<ipc::socket>> m_sockets;
 #endif
 	std::string m_socketPath = "";
+	bool m_activateWatchdog = false;
 
 	// Client management.
 	std::mutex m_clients_mtx;
@@ -96,6 +97,7 @@ public:
 public: // Status
 	void initialize(std::string socketPath);
 	void finalize();
+	void set_watchdog(bool activateWatchdog);
 
 public: // Events
 	void set_connect_handler(server_connect_handler_t handler, void *data);

--- a/source/apple/ipc-server-instance-osx.cpp
+++ b/source/apple/ipc-server-instance-osx.cpp
@@ -1,11 +1,11 @@
 #include "ipc-server-instance-osx.hpp"
 
-std::shared_ptr<ipc::server_instance> ipc::server_instance::create(server *owner, std::shared_ptr<ipc::socket> socket)
+std::shared_ptr<ipc::server_instance> ipc::server_instance::create(server *owner, std::shared_ptr<ipc::socket> socket, bool activate_watchdog)
 {
-	return std::make_unique<ipc::server_instance_osx>(owner, socket);
+	return std::make_unique<ipc::server_instance_osx>(owner, socket, activate_watchdog);
 }
 
-ipc::server_instance_osx::server_instance_osx(ipc::server *owner, std::shared_ptr<ipc::socket> conn)
+ipc::server_instance_osx::server_instance_osx(ipc::server *owner, std::shared_ptr<ipc::socket> conn, bool activate_watchdog)
 {
 	m_parent = owner;
 	m_socket = std::dynamic_pointer_cast<os::apple::socket_osx>(conn);

--- a/source/apple/ipc-server-instance-osx.cpp
+++ b/source/apple/ipc-server-instance-osx.cpp
@@ -1,11 +1,11 @@
 #include "ipc-server-instance-osx.hpp"
 
-std::shared_ptr<ipc::server_instance> ipc::server_instance::create(server *owner, std::shared_ptr<ipc::socket> socket, bool activate_watchdog)
+std::shared_ptr<ipc::server_instance> ipc::server_instance::create(server *owner, std::shared_ptr<ipc::socket> socket, int call_timeout)
 {
-	return std::make_unique<ipc::server_instance_osx>(owner, socket, activate_watchdog);
+	return std::make_unique<ipc::server_instance_osx>(owner, socket, call_timeout);
 }
 
-ipc::server_instance_osx::server_instance_osx(ipc::server *owner, std::shared_ptr<ipc::socket> conn, bool activate_watchdog)
+ipc::server_instance_osx::server_instance_osx(ipc::server *owner, std::shared_ptr<ipc::socket> conn, int call_timeout)
 {
 	m_parent = owner;
 	m_socket = std::dynamic_pointer_cast<os::apple::socket_osx>(conn);

--- a/source/apple/ipc-server-instance-osx.hpp
+++ b/source/apple/ipc-server-instance-osx.hpp
@@ -7,7 +7,7 @@ class server;
 
 class server_instance_osx : public server_instance {
 public:
-	server_instance_osx(server *owner, std::shared_ptr<ipc::socket> socket);
+	server_instance_osx(server *owner, std::shared_ptr<ipc::socket> socket, bool activate_watchdog);
 	~server_instance_osx();
 
 private:

--- a/source/ipc-server.cpp
+++ b/source/ipc-server.cpp
@@ -121,7 +121,7 @@ void ipc::server::spawn_client(std::shared_ptr<ipc::socket> socket)
 {
 	std::unique_lock<std::mutex> ul(m_clients_mtx);
 	//std::shared_ptr<ipc::server_instance> client = std::make_shared<ipc::server_instance>(this, socket);
-	std::shared_ptr<ipc::server_instance> client = ipc::server_instance::create(this, socket, m_activateWatchdog);
+	std::shared_ptr<ipc::server_instance> client = ipc::server_instance::create(this, socket, m_callTimeout);
 	if (m_handlerConnect.first) {
 		m_handlerConnect.first(m_handlerConnect.second, 0);
 	}
@@ -147,7 +147,7 @@ void ipc::server::spawn_client(std::shared_ptr<ipc::socket> socket)
 	std::unique_lock<std::mutex> ul(m_clients_mtx);
 
 	// std::shared_ptr<ipc::server_instance> client = std::make_shared<ipc::server_instance>(this, socket);
-	std::shared_ptr<ipc::server_instance> client = ipc::server_instance::create(this, socket, m_activateWatchdog);
+	std::shared_ptr<ipc::server_instance> client = ipc::server_instance::create(this, socket, m_callTimeout);
 	if (m_handlerConnect.first) {
 		m_handlerConnect.first(m_handlerConnect.second, 0);
 	}
@@ -221,9 +221,9 @@ void ipc::server::finalize()
 	m_sockets.clear();
 }
 
-void ipc::server::set_watchdog(bool activateWatchdog)
+void ipc::server::set_call_timeout(int callTimeout)
 {
-	m_activateWatchdog = activateWatchdog;
+	m_callTimeout = callTimeout;
 }
 
 void ipc::server::set_connect_handler(server_connect_handler_t handler, void *data)

--- a/source/ipc-server.cpp
+++ b/source/ipc-server.cpp
@@ -121,7 +121,7 @@ void ipc::server::spawn_client(std::shared_ptr<ipc::socket> socket)
 {
 	std::unique_lock<std::mutex> ul(m_clients_mtx);
 	//std::shared_ptr<ipc::server_instance> client = std::make_shared<ipc::server_instance>(this, socket);
-	std::shared_ptr<ipc::server_instance> client = ipc::server_instance::create(this, socket);
+	std::shared_ptr<ipc::server_instance> client = ipc::server_instance::create(this, socket, m_activateWatchdog);
 	if (m_handlerConnect.first) {
 		m_handlerConnect.first(m_handlerConnect.second, 0);
 	}
@@ -147,7 +147,7 @@ void ipc::server::spawn_client(std::shared_ptr<ipc::socket> socket)
 	std::unique_lock<std::mutex> ul(m_clients_mtx);
 
 	// std::shared_ptr<ipc::server_instance> client = std::make_shared<ipc::server_instance>(this, socket);
-	std::shared_ptr<ipc::server_instance> client = ipc::server_instance::create(this, socket);
+	std::shared_ptr<ipc::server_instance> client = ipc::server_instance::create(this, socket, m_activateWatchdog);
 	if (m_handlerConnect.first) {
 		m_handlerConnect.first(m_handlerConnect.second, 0);
 	}
@@ -219,6 +219,11 @@ void ipc::server::finalize()
 
 	// Kill any remaining sockets
 	m_sockets.clear();
+}
+
+void ipc::server::set_watchdog(bool activateWatchdog)
+{
+	m_activateWatchdog = activateWatchdog;
 }
 
 void ipc::server::set_connect_handler(server_connect_handler_t handler, void *data)

--- a/source/windows/ipc-server-instance-win.cpp
+++ b/source/windows/ipc-server-instance-win.cpp
@@ -5,12 +5,12 @@
 
 using namespace std::placeholders;
 
-std::shared_ptr<ipc::server_instance> ipc::server_instance::create(server *owner, std::shared_ptr<ipc::socket> socket)
+std::shared_ptr<ipc::server_instance> ipc::server_instance::create(server *owner, std::shared_ptr<ipc::socket> socket, bool activate_watchdog)
 {
-	return std::make_unique<ipc::server_instance_win>(owner, socket);
+	return std::make_unique<ipc::server_instance_win>(owner, socket, activate_watchdog);
 }
 
-ipc::server_instance_win::server_instance_win(server *owner, std::shared_ptr<ipc::socket> socket)
+ipc::server_instance_win::server_instance_win(server *owner, std::shared_ptr<ipc::socket> socket, bool activate_watchdog)
 {
 	m_stopWorkers = false;
 	m_parent = owner;
@@ -18,7 +18,8 @@ ipc::server_instance_win::server_instance_win(server *owner, std::shared_ptr<ipc
 	m_socket = std::dynamic_pointer_cast<os::windows::socket_win>(socket);
 	m_worker = std::thread(std::bind(&ipc::server_instance_win::worker, this));
 
-	m_watchdog_thread = std::thread(std::bind(&server_instance_win::watchdog_callbacks, this));
+	if (activate_watchdog)
+		m_watchdog_thread = std::thread(std::bind(&server_instance_win::watchdog_callbacks, this));
 }
 
 ipc::server_instance_win::~server_instance_win()

--- a/source/windows/ipc-server-instance-win.cpp
+++ b/source/windows/ipc-server-instance-win.cpp
@@ -17,6 +17,8 @@ ipc::server_instance_win::server_instance_win(server *owner, std::shared_ptr<ipc
 	m_clientId = 0;
 	m_socket = std::dynamic_pointer_cast<os::windows::socket_win>(socket);
 	m_worker = std::thread(std::bind(&ipc::server_instance_win::worker, this));
+
+	m_watchdog_thread = std::thread(std::bind(&server_instance_win::watchdog_callbacks, this));
 }
 
 ipc::server_instance_win::~server_instance_win()
@@ -25,6 +27,22 @@ ipc::server_instance_win::~server_instance_win()
 	m_stopWorkers = true;
 	if (m_worker.joinable())
 		m_worker.join();
+	if (m_watchdog_thread.joinable())
+		m_watchdog_thread.join();
+}
+
+void ipc::server_instance_win::watchdog_callbacks()
+{
+	while (!m_stopWorkers) {
+		std::unique_lock<std::mutex> lock(m_watchdog_mutex);
+		if (m_write_waiting) {
+			if (std::chrono::steady_clock::now() - last_write_time > std::chrono::seconds(30)) {
+				throw std::exception("No write in 30 seconds");
+			}
+		}
+		lock.unlock();
+		std::this_thread::sleep_for(std::chrono::milliseconds(100));
+	}
 }
 
 void ipc::server_instance_win::worker()
@@ -54,9 +72,15 @@ void ipc::server_instance_win::worker()
 					if (ec == os::error::Disconnected) {
 						break;
 					} else {
-						throw std::exception("Unexpected error.");
+						const DWORD parent_proc_exit_code = os::windows::utility::get_parent_process_exit_code();
+						ipc::log("Write buffer operation failed with error %d %p, pp_exit_code=%d", static_cast<int>(ec), &fbuf, parent_proc_exit_code);
+						throw std::exception("Write buffer operation failed");
 					}
 				}
+
+				std::unique_lock<std::mutex> lock(m_watchdog_mutex);
+				m_write_waiting = false;
+				lock.unlock();
 				m_write_queue.pop();
 			}
 		}
@@ -117,7 +141,13 @@ void ipc::server_instance_win::read_callback_msg(os::error ec, size_t size)
 	ipc::message::function_call fnc_call_msg;
 	ipc::message::function_reply fnc_reply_msg;
 
+	std::unique_lock<std::mutex> lock(m_watchdog_mutex);
+	m_write_waiting = true;
+	last_write_time = std::chrono::steady_clock::now();
+	lock.unlock();
+
 	if (ec != os::error::Success) {
+		throw std::exception("Unexpected error.");
 		return;
 	}
 
@@ -127,6 +157,7 @@ void ipc::server_instance_win::read_callback_msg(os::error ec, size_t size)
 		fnc_call_msg.deserialize(m_rbuf, 0);
 	} catch (std::exception &e) {
 		ipc::log("????????: Deserialization of Function Call message failed with error %s.", e.what());
+		throw std::exception("Deserialization of Function Call message failed.");
 		return;
 	}
 
@@ -148,6 +179,7 @@ void ipc::server_instance_win::read_callback_msg(os::error ec, size_t size)
 		fnc_reply_msg.serialize(write_buffer, sizeof(ipc_size_t));
 	} catch (std::exception &e) {
 		ipc::log("%8llu: Serialization of Function Reply message failed with error %s.", fnc_reply_msg.uid.value_union.ui64, e.what());
+		throw std::exception("Serialization of Function Reply message failed.");
 		return;
 	}
 
@@ -157,23 +189,7 @@ void ipc::server_instance_win::read_callback_msg(os::error ec, size_t size)
 void ipc::server_instance_win::read_callback_msg_write(std::vector<char> &write_buffer)
 {
 	if (write_buffer.size() != 0) {
-		if ((!m_wop || !m_wop->is_valid()) && (m_write_queue.size() == 0)) {
-			ipc::make_sendable(write_buffer);
-			os::error ec2 = m_socket->write(write_buffer.data(), write_buffer.size(), m_wop,
-							std::bind(&ipc::server_instance_win::write_callback, this, _1, _2));
-			if (ec2 != os::error::Success && ec2 != os::error::Pending) {
-				if (ec2 == os::error::Disconnected) {
-					return;
-				} else {
-					const DWORD parent_proc_exit_code = os::windows::utility::get_parent_process_exit_code();
-					ipc::log("Write buffer operation failed with error %d %p, pp_exit_code=%d", static_cast<int>(ec2), &write_buffer,
-						 parent_proc_exit_code);
-					throw std::exception("Write buffer operation failed");
-				}
-			}
-		} else {
-			m_write_queue.push(std::move(write_buffer));
-		}
+		m_write_queue.push(std::move(write_buffer));
 	} else {
 		m_rop->invalidate();
 	}

--- a/source/windows/ipc-server-instance-win.cpp
+++ b/source/windows/ipc-server-instance-win.cpp
@@ -5,12 +5,12 @@
 
 using namespace std::placeholders;
 
-std::shared_ptr<ipc::server_instance> ipc::server_instance::create(server *owner, std::shared_ptr<ipc::socket> socket, bool activate_watchdog)
+std::shared_ptr<ipc::server_instance> ipc::server_instance::create(server *owner, std::shared_ptr<ipc::socket> socket, int call_timeout)
 {
-	return std::make_unique<ipc::server_instance_win>(owner, socket, activate_watchdog);
+	return std::make_unique<ipc::server_instance_win>(owner, socket, call_timeout);
 }
 
-ipc::server_instance_win::server_instance_win(server *owner, std::shared_ptr<ipc::socket> socket, bool activate_watchdog)
+ipc::server_instance_win::server_instance_win(server *owner, std::shared_ptr<ipc::socket> socket, int call_timeout)
 {
 	m_stopWorkers = false;
 	m_parent = owner;
@@ -18,8 +18,8 @@ ipc::server_instance_win::server_instance_win(server *owner, std::shared_ptr<ipc
 	m_socket = std::dynamic_pointer_cast<os::windows::socket_win>(socket);
 	m_worker = std::thread(std::bind(&ipc::server_instance_win::worker, this));
 
-	if (activate_watchdog)
-		m_watchdog_thread = std::thread(std::bind(&server_instance_win::watchdog_callbacks, this));
+	if (call_timeout)
+		m_watchdog_thread = std::thread(std::bind(&server_instance_win::watchdog_callbacks, this, call_timeout));
 }
 
 ipc::server_instance_win::~server_instance_win()
@@ -32,12 +32,12 @@ ipc::server_instance_win::~server_instance_win()
 		m_watchdog_thread.join();
 }
 
-void ipc::server_instance_win::watchdog_callbacks()
+void ipc::server_instance_win::watchdog_callbacks(int call_timeout)
 {
 	while (!m_stopWorkers) {
 		std::unique_lock<std::mutex> lock(m_watchdog_mutex);
 		if (m_write_waiting) {
-			if (std::chrono::steady_clock::now() - last_write_time > std::chrono::seconds(30)) {
+			if (std::chrono::steady_clock::now() - m_last_write_time > std::chrono::seconds(call_timeout)) {
 				throw std::exception("No write in 30 seconds");
 			}
 		}
@@ -145,7 +145,7 @@ void ipc::server_instance_win::read_callback_msg(os::error ec, size_t size)
 
 	std::unique_lock<std::mutex> lock(m_watchdog_mutex);
 	m_write_waiting = true;
-	last_write_time = std::chrono::steady_clock::now();
+	m_last_write_time = std::chrono::steady_clock::now();
 	lock.unlock();
 
 	if (ec != os::error::Success) {

--- a/source/windows/ipc-server-instance-win.cpp
+++ b/source/windows/ipc-server-instance-win.cpp
@@ -73,7 +73,8 @@ void ipc::server_instance_win::worker()
 						break;
 					} else {
 						const DWORD parent_proc_exit_code = os::windows::utility::get_parent_process_exit_code();
-						ipc::log("Write buffer operation failed with error %d %p, pp_exit_code=%d", static_cast<int>(ec), &fbuf, parent_proc_exit_code);
+						ipc::log("Write buffer operation failed with error %d %p, pp_exit_code=%d", static_cast<int>(ec), &fbuf,
+							 parent_proc_exit_code);
 						throw std::exception("Write buffer operation failed");
 					}
 				}

--- a/source/windows/ipc-server-instance-win.hpp
+++ b/source/windows/ipc-server-instance-win.hpp
@@ -20,12 +20,12 @@ private:
 
 	std::thread m_watchdog_thread;
 	std::mutex m_watchdog_mutex;
-	void watchdog_callbacks();
-	std::chrono::steady_clock::time_point last_write_time;
+	void watchdog_callbacks(int call_timeout);
+	std::chrono::steady_clock::time_point m_last_write_time;
 	bool m_write_waiting = false;
 
 public:
-	server_instance_win(server *owner, std::shared_ptr<ipc::socket> socket, bool activate_watchdog);
+	server_instance_win(server *owner, std::shared_ptr<ipc::socket> socket, int call_timeout);
 	~server_instance_win();
 
 public:

--- a/source/windows/ipc-server-instance-win.hpp
+++ b/source/windows/ipc-server-instance-win.hpp
@@ -25,7 +25,7 @@ private:
 	bool m_write_waiting = false;
 
 public:
-	server_instance_win(server *owner, std::shared_ptr<ipc::socket> socket);
+	server_instance_win(server *owner, std::shared_ptr<ipc::socket> socket, bool activate_watchdog);
 	~server_instance_win();
 
 public:

--- a/source/windows/ipc-server-instance-win.hpp
+++ b/source/windows/ipc-server-instance-win.hpp
@@ -18,6 +18,12 @@ private:
 	server *m_parent = nullptr;
 	int64_t m_clientId;
 
+	std::thread m_watchdog_thread;
+	std::mutex m_watchdog_mutex;
+	void watchdog_callbacks();
+	std::chrono::steady_clock::time_point last_write_time;
+	bool m_write_waiting = false;
+
 public:
 	server_instance_win(server *owner, std::shared_ptr<ipc::socket> socket);
 	~server_instance_win();


### PR DESCRIPTION
thread will monitor ipc calls on server side. 
and force a crash if ipc call takes longer them set threshold. 
it will let us collect memory dumps of such incidents. 