### PR TITLE
increase buffer size to resolve mac shutdown crash

### DIFF
--- a/source/apple/ipc-server-instance-osx.cpp
+++ b/source/apple/ipc-server-instance-osx.cpp
@@ -31,7 +31,7 @@ ipc::server_instance_osx::~server_instance_osx()
 	m_stopWorkers = true;
 
 	// Unblock current sync read by send dummy data
-	std::vector<char> buffer;
+	std::vector<char> buffer(1 + sizeof(ipc_size_t));
 	buffer.push_back('1');
 	ipc::make_sendable(buffer);
 	m_socket->write(buffer.data(), buffer.size(), REQUEST);

--- a/source/apple/ipc-server-instance-osx.cpp
+++ b/source/apple/ipc-server-instance-osx.cpp
@@ -31,7 +31,7 @@ ipc::server_instance_osx::~server_instance_osx()
 	m_stopWorkers = true;
 
 	// Unblock current sync read by send dummy data
-	std::vector<char> buffer(1 + sizeof(ipc_size_t));
+	std::vector<char> buffer(sizeof(ipc_size_t));
 	buffer.push_back('1');
 	ipc::make_sendable(buffer);
 	m_socket->write(buffer.data(), buffer.size(), REQUEST);


### PR DESCRIPTION
fix for a crash I saw with the xcode debugger connected. Increasing buffer size like we do everywhere else to resolve the issue

<img width="2750" height="891" alt="image" src="https://github.com/user-attachments/assets/657b2324-b67b-4833-8003-831c0fb6d6a1" />
