### PR TITLE
[Mac] increase buffer size to resolve mac shutdown crash

### DIFF
--- a/source/apple/ipc-server-instance-osx.cpp
+++ b/source/apple/ipc-server-instance-osx.cpp
@@ -31,7 +31,7 @@ ipc::server_instance_osx::~server_instance_osx()
 	m_stopWorkers = true;
 
 	// Unblock current sync read by send dummy data
-	std::vector<char> buffer;
+	std::vector<char> buffer(sizeof(ipc_size_t));
 	buffer.push_back('1');
 	ipc::make_sendable(buffer);
 	m_socket->write(buffer.data(), buffer.size(), REQUEST);


### PR DESCRIPTION
fix for a crash I saw with the xcode debugger connected. Increasing buffer size like we do everywhere else to resolve the issue