### PR TITLE
fix xcode warnings: add type::Null && fix int <-> size_t conversions

### DIFF
--- a/source/apple/ipc-socket-osx.cpp
+++ b/source/apple/ipc-socket-osx.cpp
@@ -62,7 +62,7 @@ void os::apple::socket_osx::clean_file_descriptors()
 uint32_t os::apple::socket_osx::read(char *buffer, size_t buffer_length, bool is_blocking, SocketType t)
 {
 	os::error err = os::error::Error;
-	int ret = 0;
+	size_t ret = 0;
 	int sizeChunks = 8 * 1024; // 8KB
 	int offset = 0;
 	int file_descriptor = -1;
@@ -117,7 +117,7 @@ end:
 uint32_t os::apple::socket_osx::write(const char *buffer, size_t buffer_length, SocketType t)
 {
 	os::error err = os::error::Error;
-	int ret = 0;
+	size_t ret = 0;
 	int sizeChunks = 8 * 1024; // 8KB
 	std::string typePipe = t == REQUEST ? "client" : "server";
 
@@ -138,7 +138,7 @@ uint32_t os::apple::socket_osx::write(const char *buffer, size_t buffer_length, 
 				fd_write = open(t == REQUEST ? name_req.c_str() : name_rep.c_str(), O_WRONLY | O_DSYNC);
 
 			bool end = (buffer_length - size_wrote) <= sizeChunks;
-			int size_to_write = end ? buffer_length - size_wrote : sizeChunks;
+			size_t size_to_write = end ? buffer_length - size_wrote : sizeChunks;
 			ret = ::write(fd_write, buffer + size_wrote, size_to_write);
 			if (ret < 0)
 				break;

--- a/source/ipc-value.cpp
+++ b/source/ipc-value.cpp
@@ -101,6 +101,8 @@ size_t ipc::value::size()
 		size += sizeof(uint32_t);
 		size += this->value_bin.size();
 		break;
+	case type::Null:
+		break;
 	}
 	return size;
 }
@@ -120,6 +122,7 @@ size_t ipc::value::serialize(std::vector<char> &buf, size_t offset)
 		reinterpret_cast<int32_t &>(buf[noffset]) = this->value_union.i32;
 		noffset += sizeof(int32_t);
 		break;
+	case type::Null:
 	case type::UInt32:
 		reinterpret_cast<uint32_t &>(buf[noffset]) = this->value_union.ui32;
 		noffset += sizeof(uint32_t);
@@ -176,6 +179,7 @@ size_t ipc::value::deserialize(const std::vector<char> &buf, size_t offset)
 	size_t noffset = offset + sizeof(uint32_t);
 	uint32_t length;
 	switch (this->type) {
+	case type::Null:
 	case type::Int32:
 	case type::UInt32:
 	case type::Float:


### PR DESCRIPTION
* treating type::Null as uint32 (*kinda* matches legacy behavior due to unhandled case)