### PR TITLE
xcode warnings

### DIFF
--- a/source/apple/ipc-socket-osx.cpp
+++ b/source/apple/ipc-socket-osx.cpp
@@ -62,7 +62,7 @@ void os::apple::socket_osx::clean_file_descriptors()
 uint32_t os::apple::socket_osx::read(char *buffer, size_t buffer_length, bool is_blocking, SocketType t)
 {
 	os::error err = os::error::Error;
-	size_t ret = 0;
+	long ret = 0;
 	int sizeChunks = 8 * 1024; // 8KB
 	int offset = 0;
 	int file_descriptor = -1;
@@ -117,7 +117,7 @@ end:
 uint32_t os::apple::socket_osx::write(const char *buffer, size_t buffer_length, SocketType t)
 {
 	os::error err = os::error::Error;
-	size_t ret = 0;
+	long ret = 0;
 	int sizeChunks = 8 * 1024; // 8KB
 	std::string typePipe = t == REQUEST ? "client" : "server";
 

--- a/source/ipc-value.cpp
+++ b/source/ipc-value.cpp
@@ -78,6 +78,7 @@ size_t ipc::value::size()
 	case type::Int32:
 		size += sizeof(int32_t);
 		break;
+	case type::Null:
 	case type::UInt32:
 		size += sizeof(uint32_t);
 		break;
@@ -100,8 +101,6 @@ size_t ipc::value::size()
 	case type::Binary:
 		size += sizeof(uint32_t);
 		size += this->value_bin.size();
-		break;
-	case type::Null:
 		break;
 	}
 	return size;


### PR DESCRIPTION
* treat Null type same as UInt32 by default (same as the change I made elsewhere)
* meant to use long here (instead of size_t) just incase `read` or `write` function returns negative integer

